### PR TITLE
Remove activesupport less-than version

### DIFF
--- a/lib/srfax/version.rb
+++ b/lib/srfax/version.rb
@@ -1,3 +1,3 @@
 module SrFax
-  VERSION = '0.5.5'.freeze
+  VERSION = '0.5.6'.freeze
 end

--- a/srfax.gemspec
+++ b/srfax.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry', '~> 0.8'
   spec.add_development_dependency 'yard', '~> 0.8'
   spec.add_dependency 'logger', '~> 1'
-  spec.add_dependency 'activesupport', ['>= 4.2', '< 6']
+  spec.add_dependency 'activesupport', '>= 4.2'
   spec.add_dependency 'rest-client', '~> 2.0'
 end


### PR DESCRIPTION
ActiveSupport::HashWithIndifferentAccess has not changed so there is no reason to limit the `activesupport` version to `< 6`